### PR TITLE
jessie and xenial pbuilder configurations

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -56,17 +56,20 @@ nodes = {
         'labels': ['amd64', 'x86_64', 'jessie', 'small', 'rebootable'],
         'provider': 'openstack'
     },
-    'jessie_huge': {
-        'script': dedent("""#!/bin/bash
-        apt-get update && apt-get install -y -q curl
-        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+jessie+huge+x86_64+rebootable&nodename=jessie_huge__%s" | bash
-        """),
-        'keyname': keyname,
-        'image_name': 'Debian 8',
-        'size': 'hg-30',
-        'labels': ['amd64', 'x86_64', 'jessie', 'huge', 'rebootable'],
-        'provider': 'openstack'
-    },
+# XXX Currently disabled because we don't have pre-fab images that contain installed deps. This particular
+# machine can take +40 minutes to get ready (vs. 6 minutes for other nodes). It is only used for Ceph builds
+# so this service is now configuring a "pbuilder" machine (Ubuntu Trusty) that can build Jessie.
+#    'jessie_huge': {
+#        'script': dedent("""#!/bin/bash
+#        apt-get update && apt-get install -y -q curl
+#        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+jessie+huge+x86_64+rebootable&nodename=jessie_huge__%s" | bash
+#        """),
+#        'keyname': keyname,
+#        'image_name': 'Debian 8',
+#        'size': 'hg-30',
+#        'labels': ['amd64', 'x86_64', 'jessie', 'huge', 'rebootable'],
+#        'provider': 'openstack'
+#    },
     'ceph_ansible_pr_trusty': {
         'script': dedent("""#!/bin/bash
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=ceph_ansible_pr_trusty&nodename=ceph_ansible_pr_trusty__%s" | bash
@@ -88,9 +91,19 @@ nodes = {
         'labels': ['amd64', 'x86_64', 'trusty', 'small', 'rebootable'],
         'provider': 'openstack'
     },
+    'jessie_trusty_pbuilder_huge': {
+        'script': dedent("""#!/bin/bash
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+huge+jessie+x86_64+rebootable+trusty-pbuilder&nodename=jessie_trusty_pbuilder_huge__%s" | bash
+        """),
+        'keyname': keyname,
+        'image_name': 'Ubuntu 14.04',
+        'size': 'hg-30',
+        'labels': ['trusty-pbuilder', 'amd64', 'x86_64', 'jessie', 'huge', 'rebootable'],
+        'provider': 'openstack'
+    },
     'xenial_trusty_pbuilder_huge': {
         'script': dedent("""#!/bin/bash
-        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+huge+xenial+x86_64+rebootable+pbuilder-trusty&nodename=xenial_trusty_pbuilder_huge__%s" | bash
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+huge+xenial+x86_64+rebootable+trusty-pbuilder&nodename=xenial_trusty_pbuilder_huge__%s" | bash
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 14.04',

--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -88,14 +88,14 @@ nodes = {
         'labels': ['amd64', 'x86_64', 'trusty', 'small', 'rebootable'],
         'provider': 'openstack'
     },
-    'trusty_pbuilder_huge': {
+    'xenial_trusty_pbuilder_huge': {
         'script': dedent("""#!/bin/bash
-        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+trusty+huge+xenial+wheezy+precise+jessie+x86_64+rebootable+pbuilder-trusty&nodename=trusty_pbuilder_huge__%s" | bash
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+huge+xenial+x86_64+rebootable+pbuilder-trusty&nodename=xenial_trusty_pbuilder_huge__%s" | bash
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 14.04',
         'size': 'hg-30',
-        'labels': ['trusty-pbuilder', 'amd64', 'x86_64', 'trusty', 'xenial', 'wheezy', 'precise', 'jessie', 'huge', 'rebootable'],
+        'labels': ['trusty-pbuilder', 'amd64', 'x86_64', 'xenial', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
     'trusty_huge': {


### PR DESCRIPTION
Because I couldn't get the combination filter to work out. This will have a "trusty" machine that only provides the "xenial" label. As it was before (providing labels for other distros) it would get picked up by other jobs requiring other distro versions (e.g. 'trusty').

It also disables the Jessie image and provides a 'trusty-pbuilder' one instead.