### PR TITLE
prod_nodes: Adding ceph-builders-xenial support

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -179,6 +179,15 @@ nodes = {
         'labels': ['amd64', 'x86_64', 'centos7', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
+    'ceph-build-xenial': {
+        'script': dedent("""#!/bin/bash
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+huge+xfs+ceph-build-xenial+x86_64+rebootable&nodename=ceph-build-xenial__%s" | bash"""),
+        'keyname': keyname,
+        'image_name': 'ceph-builders-U16.04-1.0.0',
+        'size': 'hg-30',
+        'labels': ['ceph-build-xenial', 'amd64', 'x86_64', 'xfs', 'huge', 'rebootable'],
+        'provider': 'openstack'
+    },
     '__force_dict__': True
 
 }


### PR DESCRIPTION
This patch aims at creating a new type of node. It is based on xenial and
provides all the packages required to build ceph or edeploy images.