### PR TITLE
prod_nodes: Changing dashes by underscores

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -179,13 +179,13 @@ nodes = {
         'labels': ['amd64', 'x86_64', 'centos7', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
-    'ceph-build-xenial': {
+    'ceph_build_xenial': {
         'script': dedent("""#!/bin/bash
-        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+huge+xfs+ceph-build-xenial+x86_64+rebootable&nodename=ceph-build-xenial__%s" | bash"""),
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+huge+xfs+ceph_build_xenial+x86_64+rebootable&nodename=ceph_build_xenial__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'ceph-builders-U16.04-1.0.0',
         'size': 'hg-30',
-        'labels': ['ceph-build-xenial', 'amd64', 'x86_64', 'xfs', 'huge', 'rebootable'],
+        'labels': ['ceph_build_xenial', 'amd64', 'x86_64', 'xfs', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
     '__force_dict__': True


### PR DESCRIPTION
When labels are featuing dashes, it triggers the following exception :

  File "/opt/mita/local/lib/python2.7/site-packages/gunicorn/arbiter.py", line 515, in spawn_worker
    worker.init_process()
  File "/opt/mita/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 122, in init_process
    self.load_wsgi()
  File "/opt/mita/local/lib/python2.7/site-packages/gunicorn/workers/base.py", line 130, in load_wsgi
    self.wsgi = self.app.wsgi()
  File "/opt/mita/local/lib/python2.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
    self.callable = self.load()
  File "/opt/mita/local/lib/python2.7/site-packages/pecan/commands/serve.py", line 196, in load
    return deploy(self.cfgfname)
  File "/opt/mita/local/lib/python2.7/site-packages/pecan/deploy.py", line 9, in deploy
    return load_app(config)
  File "/opt/mita/local/lib/python2.7/site-packages/pecan/core.py", line 216, in load_app
    set_config(config, overwrite=True)
  File "/opt/mita/local/lib/python2.7/site-packages/pecan/configuration.py", line 249, in set_config
    config = conf_from_file(config)
  File "/opt/mita/local/lib/python2.7/site-packages/pecan/configuration.py", line 186, in conf_from_file
    return conf_from_dict(conf_dict)
  File "/opt/mita/local/lib/python2.7/site-packages/pecan/configuration.py", line 221, in conf_from_dict
    conf[k] = v
  File "/opt/mita/local/lib/python2.7/site-packages/pecan/configuration.py", line 133, in __setitem__
    self.__values__[key] = Config(value, filename=self.__file__)
  File "/opt/mita/local/lib/python2.7/site-packages/pecan/configuration.py", line 52, in __init__
    self.update(conf_dict)
  File "/opt/mita/local/lib/python2.7/site-packages/pecan/configuration.py", line 72, in update
    raise ValueError('\'%s\' is not a valid indentifier' % k)
ValueError: 'ceph-build-xenial' is not a valid indentifier

This patch simply change the dashes by underscores then.