### PR TITLE
prod_nodes: Switching from hg-30 to hg-30-ssd

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -19,7 +19,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 12.04',
-        'size': 'hg-30',
+        'size': 'hg-30-ssd',
         'labels': ['amd64', 'x86_64', 'precise', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -41,7 +41,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'Debian 7',
-        'size': 'hg-30',
+        'size': 'hg-30-ssd',
         'labels': ['amd64', 'x86_64', 'wheezy', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -66,7 +66,7 @@ nodes = {
 #        """),
 #        'keyname': keyname,
 #        'image_name': 'Debian 8',
-#        'size': 'hg-30',
+#        'size': 'hg-30-ssd',
 #        'labels': ['amd64', 'x86_64', 'jessie', 'huge', 'rebootable'],
 #        'provider': 'openstack'
 #    },
@@ -109,7 +109,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'ceph-builders-U14.04-1.0.1',
-        'size': 'hg-30',
+        'size': 'hg-30-ssd',
         'labels': ['trusty-pbuilder', 'amd64', 'x86_64', 'jessie', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -119,7 +119,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'ceph-builders-U14.04-1.0.1',
-        'size': 'hg-30',
+        'size': 'hg-30-ssd',
         'labels': ['trusty-pbuilder', 'amd64', 'x86_64', 'xenial', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -129,7 +129,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'ceph-builders-U14.04-1.0.1',
-        'size': 'hg-30',
+        'size': 'hg-30-ssd',
         'labels': ['amd64', 'x86_64', 'trusty', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -147,7 +147,7 @@ nodes = {
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=2&labels=amd64+centos6+x86_64+huge+rebootable&nodename=centos6_huge__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'Centos 6',
-        'size': 'hg-30',
+        'size': 'hg-30-ssd',
         'labels': ['amd64', 'x86_64', 'centos6', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -175,7 +175,7 @@ nodes = {
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=2&labels=amd64+centos7+huge+x86_64+rebootable&nodename=centos7_huge__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'ceph-builders-C7.2-1.0.1',
-        'size': 'hg-30',
+        'size': 'hg-30-ssd',
         'labels': ['amd64', 'x86_64', 'centos7', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -184,7 +184,7 @@ nodes = {
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&executors=1&labels=amd64+huge+xfs+ceph_build_xenial+x86_64+rebootable&nodename=ceph_build_xenial__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'ceph-builders-U16.04-1.0.0',
-        'size': 'hg-30',
+        'size': 'hg-30-ssd',
         'labels': ['ceph_build_xenial', 'amd64', 'x86_64', 'xfs', 'huge', 'rebootable'],
         'provider': 'openstack'
     },


### PR DESCRIPTION
This change does for the same price a switch to a local ssd with no raid
instead of a redunded rbd. That will speedup things while we don't care about
the redunduncy.