### PR TITLE
util: from_offline_executor() shall not assert if builtOn is undefined

### DIFF
--- a/mita/util.py
+++ b/mita/util.py
@@ -216,8 +216,9 @@ def from_offline_executor(node):
     # by splitting on possible use of __IP'
     match = get_key(configured_nodes, node)
     if match is None:
-        node = node.split('__')[0]
-        match = node if node in configured_nodes else None
+        if node is not None:
+            node = node.split('__')[0]
+            match = node if node in configured_nodes else None
     return match
 
 


### PR DESCRIPTION
We can reach a situation where a task is stuck but when trying to identified the 'builtOn' of the last job, we have a job that failed and never been scheduled to a node.
This situation leads to builtOn value set to None.

The current is unconditionnaly trying to split() it which result in a python fault :

```
[2016-06-21 09:08:06,413: ERROR/MainProcess] Task async.check_queue[f0c956eb-cb34-4df6-adc3-93433b93d940] raised unexpected: AttributeError("'NoneType' object has no attribute 'split'",)
Traceback (most recent call last):
  File "/opt/mita/local/lib/python2.7/site-packages/celery/app/trace.py", line 240, in trace_task
R = retval = fun(*args, **kwargs)
  File "/opt/mita/local/lib/python2.7/site-packages/celery/app/trace.py", line 438, in __protected_call__
return self.run(*args, **kwargs)
  File "/opt/mita/src/mita/mita/async.py", line 158, in check_queue
node_name = util.from_offline_executor(build['builtOn'])
  File "/opt/mita/src/mita/mita/util.py", line 219, in from_offline_executor
node = node.split('__')[0]
AttributeError: 'NoneType' object has no attribute 'split'
```

This patch simply test if the 'builtOn' is defined before trying to split() it.

Please find below the actual configuration that trigger the bug :
    [2016-06-21 09:49:55,981: INFO/Worker-1] found stuck task with name: ceph-pull-requests
    [2016-06-21 09:49:55,981: INFO/Worker-1] reason was: All nodes of label ?huge&&(centos7||trusty)&&rebootable? are offline
    [2016-06-21 09:49:55,981: WARNING/Worker-1] unable to match a suitable node
    [2016-06-21 09:49:55,981: WARNING/Worker-1] will infer from builtOn
    [2016-06-21 09:49:55,992: INFO/Worker-1] determined job name as: ceph-pull-requests
    [2016-06-21 09:49:55,992: INFO/Worker-1] will look for build info on: ceph-pull-requests id: 7672
    [2016-06-21 09:49:55,998: INFO/Worker-1] found a build
    [2016-06-21 09:49:55,998: WARNING/Worker-1] completely unable to match a node to provide
    [2016-06-21 09:49:55,998: WARNING/Worker-1] {u'building': False, u'queueId': 4122, u'displayName': u'#7672', u'description': u'<a title="cmake: unittest_librbd missing a source file" href="https://github.com/ceph/ceph/pull/9832">PR #9832</a>: cmake: unittest_librbd miss...', u'changeSet': {u'items': [], u'kind': None, u'_class': u'hudson.scm.EmptyChangeLogSet'}, u'artifacts': [], u'timestamp': 1466458056440, u'number': 7672, u'actions': [{u'_class': u'hudson.model.ParametersAction', u'parameters': [{u'_class': u'hudson.model.StringParameterValue', u'name': u'sha1', u'value': u'origin/pr/9832/merge'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbActualCommit', u'value': u'716535ef9e5f4208c6cc3d321ccf3b167683c259'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbActualCommitAuthor', u'value': u'Ali Maredia'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbActualCommitAuthorEmail', u'value': u'amaredia@redhat.com'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbAuthorRepoGitUrl', u'value': u'https://github.com/ceph/ceph.git'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbTriggerAuthor', u'value': u''}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbTriggerAuthorEmail', u'value': u''}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbTriggerAuthorLogin', u'value': u''}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbTriggerAuthorLoginMention', u'value': u''}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbPullId', u'value': u'9832'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbTargetBranch', u'value': u'master'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbSourceBranch', u'value': u'wip-cmake-librbd-unittest-fix'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'GIT_BRANCH', u'value': u'wip-cmake-librbd-unittest-fix'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbPullAuthorEmail', u'value': u'amaredia@redhat.com'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbPullAuthorLogin', u'value': u'alimaredia'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbPullAuthorLoginMention', u'value': u'@alimaredia'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbPullDescription', u'value': u'GitHub pull request #9832 of commit 716535ef9e5f4208c6cc3d321ccf3b167683c259, no merge conflicts.'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbPullTitle', u'value': u'cmake: unittest_librbd missing a source file'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbPullLink', u'value': u'https://github.com/ceph/ceph/pull/9832'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbPullLongDescription', u'value': u'src/test/librbd/test_ConsistencyGroups.cc missing\r\nfrom ${unittest_librbd_srcs}.\r\n\r\nSigned-off-by: Ali Maredia amaredia@redhat.com'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbCommentBody', u'value': u'null'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbGhRepository', u'value': u'ceph/ceph'}, {u'_class': u'hudson.model.StringParameterValue', u'name': u'ghprbCredentialsId', u'value': u'041bef74-1348-4d2a-82a2-a1d0283da640'}]}, {u'_class': u'hudson.model.CauseAction', u'causes': [{u'_class': u'org.jenkinsci.plugins.ghprb.GhprbCause', u'shortDescription': u'GitHub pull request #9832 of commit 716535ef9e5f4208c6cc3d321ccf3b167683c259, no merge conflicts.'}]}, {u'_class': u'com.sonyericsson.jenkins.plugins.bfa.model.FailureCauseBuildAction'}, {}], u'id': u'7672', u'keepLog': False, u'url': u'https://jenkins.ceph.com/job/ceph-pull-requests/7672/', u'culprits': [], u'result': u'FAILURE', u'executor': None, u'duration': 392, u'builtOn': None, u'_class': u'hudson.model.FreeStyleBuild', u'fullDisplayName': u'ceph: Pull Requests #7672', u'estimatedDuration': 1529365}
