### PR TITLE
Muli label sometimes

### DIFF
--- a/mita/tests/unit/test_util.py
+++ b/mita/tests/unit/test_util.py
@@ -60,7 +60,7 @@ class TestOfflineLabel(object):
 
     def setup(self):
         set_config(
-            {'nodes': {'centos6': {'labels': ['x86_64']}}},
+            {'nodes': {'centos6': {'labels': ['x86_64', 'huge']}}},
             overwrite=True
         )
         self.msg = BecauseLabelIsOffline % 'amd64'
@@ -74,6 +74,10 @@ class TestOfflineLabel(object):
 
     def test_matches_a_label(self):
         msg = BecauseLabelIsOffline % 'x86_64'
+        assert util.from_offline_label(msg) == 'centos6'
+
+    def test_works_with_label_expression(self):
+        msg = BecauseLabelIsOffline % 'x86_64&&huge'
         assert util.from_offline_label(msg) == 'centos6'
 
 

--- a/mita/util.py
+++ b/mita/util.py
@@ -184,7 +184,11 @@ def from_offline_label(string):
     for i in to_remove:
         string = string.replace(i, '')
     label = string.split()[-3]
-    return match_node_from_label(label)
+    # first check if we get a match from a single label, e.g. 'amd64'
+    single_label_match = match_node_from_label(label)
+    # otherwise, fallback to multi-labels, like 'amd64&&trusty'
+    if not single_label_match:
+        return from_offline_node_label(label)
 
 
 def from_offline_node(string):


### PR DESCRIPTION
When a 'node label' is offline, it can contain more than one label. This change tries the more common single label approach falling back to multiple labels