### PR TITLE
async: remove node from db only when it isn't available in the API

### DIFF
--- a/mita/async.py
+++ b/mita/async.py
@@ -250,7 +250,7 @@ def check_orphaned():
                 continue
 
     # providers can purge nodes in error state too, try to prune those as well
-    for provider_name in conf.provider.keys():
+    for provider_name in pecan.conf.provider.keys():
         provider = providers.get(provider_name)
         provider.purge()
 

--- a/mita/async.py
+++ b/mita/async.py
@@ -241,14 +241,13 @@ def check_orphaned():
                 provider.destroy_node(name=node.cloud_name)
             except CloudNodeNotFound:
                 logger.info("cloud was not found on provider: %s", node.cloud_name)
-                pass
+                logger.info("will remove node from database, API confirms it no longer exists")
+                node.delete()
+                models.commit()
             except Exception:
                 logger.exception("unable to destroy node: %s", node.cloud_name)
                 logger.error("will skip database removal")
                 continue
-            node.delete()
-            models.commit()
-            logger.info("removed useless node from provider and database: %s", node)
 
     # providers can purge nodes in error state too, try to prune those as well
     for provider_name in conf.provider.keys():


### PR DESCRIPTION
This fixes a longstanding issue with OVH where mita requests a node to
be destroyed, OVH ACKs, but since the removal happens asynchronously,
there are times where the nodes sticks around. With this change we are
only removing it from the database when the API reports it is no longer
there.

Signed-off-by: Alfredo Deza <adeza@redhat.com>