### PR TITLE
config: adds a ceph_ansible_pr_yakkety node type

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -97,7 +97,19 @@ nodes = {
         'keyname': keyname,
         'image_name': 'Ubuntu 16.04',
         'size': 'hg-30-flex',
-        'labels': ['libvirt', 'vagrant', 'python3'],
+        'labels': ['ceph_ansible_pr_xenial'],
+        'provider': 'openstack'
+    },
+    'ceph_ansible_pr_yakkety': {
+        'script': dedent("""#!/bin/bash
+        apt-get install -y python-simplejson
+        apt-get install -y python
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave_libvirt/?token={{ jenkins_prado_token }}&executors=1&labels=python3+ceph_ansible_pr_yakkety+libvirt+vagrant&nodename=ceph_ansible_pr_yakkety__%s" | bash
+        """),
+        'keyname': keyname,
+        'image_name': 'Ubuntu 16.10',
+        'size': 'hg-30-flex',
+        'labels': ['ceph_ansible_pr_yakkety', 'libvirt', 'vagrant', 'python3'],
         'provider': 'openstack'
     },
     'trusty_small': {


### PR DESCRIPTION
This is now the default node type used by any jobs that
require vagrant and libvirt. We want this so we can upgrade
to the version of libvirt available in 16.10.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>