### PR TITLE
do not use librabbitmq and use pyamqp

### DIFF
--- a/mita/async.py
+++ b/mita/async.py
@@ -60,7 +60,7 @@ def bootstrap_pecan(signal, sender, **kw):
     models.init_model()
 
 
-app = Celery('mita.async', broker='amqp://guest@localhost//', include=['mita.tasks'])
+app = Celery('mita.async', broker='pyamqp://guest@localhost//', include=['mita.tasks'])
 
 
 @app.task

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ psycopg2
 gunicorn
 pecan
 sqlalchemy
-celery[librabbitmq]
+celery
 alembic
 python-jenkins
 requests


### PR DESCRIPTION
When deployed to a fresh xenial vm we saw this error in the
celery logs:

Received and deleted unknown message.  Wrong destination?!?

See: https://github.com/celery/celery/issues/3675

Signed-off-by: Andrew Schoen <aschoen@redhat.com>