### PR TITLE
Faster idle node removal

### DIFF
--- a/mita/tests/conftest.py
+++ b/mita/tests/conftest.py
@@ -26,6 +26,17 @@ def config_file():
     return os.path.join(here, 'config.py')
 
 
+class fake_jenkins(object):
+    def get_node_config(self, *a):
+        return """<?xml version="1.0" encoding="UTF-8"?><slave></slave>"""
+
+    def __getattr__(self, *a):
+        return self
+
+    def __call__(self, *a, **kw):
+        return {}
+
+
 @pytest.fixture(autouse=True)
 def no_jenkins_requests(monkeypatch):
     """
@@ -33,15 +44,6 @@ def no_jenkins_requests(monkeypatch):
     test uses it, then you are bound to this dictatorial patching, preventing
     from making actual connections.
     """
-    class fake_jenkins(object):
-        def get_node_config(self, *a):
-            return """<?xml version="1.0" encoding="UTF-8"?><slave></slave>"""
-
-        def __getattr__(self, *a):
-            return self
-
-        def __call__(self, *a, **kw):
-            return {}
     monkeypatch.setattr("jenkins.Jenkins", lambda *a: fake_jenkins())
 
 
@@ -61,7 +63,7 @@ def no_openstack_destroy_node_requests(monkeypatch):
     test uses it, then you are bound to this dictatorial patching, preventing
     from making actual connections.
     """
-    monkeypatch.setattr("mita.providers.openstack.create_node", lambda **kw: True)
+    monkeypatch.setattr("mita.providers.openstack.destroy_node", lambda **kw: True)
 
 
 


### PR DESCRIPTION
Explained in detail in commit 3c47df8 but basically, by talking to jenkins before the cloud and ensuring the node is really idle *at that time*, reduces the opportunity for it to be deleted while it is being picked up by a job. Like here:

    Building remotely on 213.32.31.177+ceph_ansible_pr_zesty__81c41988-9ceb-40fc-a17fd6a5c3424681 (libvirt python3 ceph_ansible_pr_zesty vagrant) in workspace /home/jenkins-build/build/workspace/ceph-ansible-prs-luminous-ansible2.3-bluestore_docker_dedicated_journal
    FATAL: java.io.IOException: Unexpected termination of the channel
    java.io.EOFException



