### PR TITLE
guard against unicode labels

### DIFF
--- a/mita/tests/unit/test_util.py
+++ b/mita/tests/unit/test_util.py
@@ -226,6 +226,17 @@ class TestGetNodeLabels(object):
     def setup(self):
         util.jenkins_connection = lambda: None
 
+    def test_unicode_does_not_barf(self, monkeypatch):
+        class FakeConn(object):
+            def get_node_config(self, node_name):
+                    str(node_name)
+                    return '<slave></slave>'
+
+        monkeypatch.setattr('mita.util.jenkins_connection', lambda: FakeConn())
+        name = u'\u2018vagrant\u2019'
+        result = util.get_node_labels(name)
+        assert result == []
+
     def test_get_no_node_labels(self):
         result = util.get_node_labels('trusty', _xml_configuration='<slave></slave>')
         assert result == []

--- a/mita/util.py
+++ b/mita/util.py
@@ -337,6 +337,7 @@ def get_node_labels(node_name, _xml_configuration=None):
     right tag and extracting the labels from there.
     """
     conn = jenkins_connection()
+    node_name = node_name.encode('ascii', errors='ignore')
     try:
         xml_configuration = _xml_configuration or conn.get_node_config(node_name)
     except JenkinsNotFoundException:


### PR DESCRIPTION
Jenkins loves to do this. Mita doesn't really decode to ascii everywhere, and python-jenkins uses `locals()` so we must sanitize this before passing them around.

Fixes: https://bugs.launchpad.net/python-jenkins/+bug/1775176