### PR TITLE
mita/controllers/nodes: Increasing timeout to 40mn

### DIFF
--- a/mita/controllers/nodes.py
+++ b/mita/controllers/nodes.py
@@ -57,7 +57,7 @@ class NodeController(object):
             # been set.
             difference = now - self.node.idle_since
 
-            if difference.seconds > 1200:  # 20 minutes
+            if difference.seconds > 2400:  # 40 minutes
                 # talk to Jenkins again, make sure this node didn't get picked
                 # up on its way here
                 conn = jenkins_connection()


### PR DESCRIPTION
A recent study on the CI shows that on 300 jobs:
- the average time between two jobs submisson is 25mn
- the standard deviation between two jobs submission is 50mn.
- 187 build hosts were used
- the average build takes 43mn

Since the CI is now properly using the ccache to speed the build, a
build can last 14mn when the local cache is hit.

With a timeout of 20mn, the build nodes dies before a new PR is incoming
loosing the built cache that could have been reused in we had waited a
little bit longer before destroying it.

The goal of this commit is to increase the chance that two recently
submitted PRs are sharing the same cache running on the node. As a
result, the job duration will tend to 14mn.

Signed-off-by: Erwan Velu <erwan@redhat.com>