### PR TITLE
remove unicode chars from helper util

### DIFF
--- a/mita/tests/unit/test_util.py
+++ b/mita/tests/unit/test_util.py
@@ -7,7 +7,7 @@ from mita import util
 
 from mock import patch, MagicMock
 
-BecauseNodeIsBusy = 'Waiting for next available executor on %s'
+BecauseNodeIsBusy = 'Waiting for next available executor on \u2018%s\u2019'
 BecauseLabelIsBusy = BecauseNodeIsBusy
 BecauseLabelIsOffline = u"All nodes of label \u2018%s\u2019 are offline"
 BecauseNodeIsOffline = "%s is offline"
@@ -26,7 +26,7 @@ class TestFromLabel(object):
 
     def setup(self):
         self.default_conf = {
-            'nodes': {'wheezy': {'labels': ['amd64']}},
+            'nodes': {'wheezy': {'labels': ['amd64', 'huge']}},
             'jenkins': {
                 'url': 'http://jenkins.example.com',
                 'user': 'alfredo',
@@ -65,6 +65,10 @@ class TestFromLabel(object):
     def test_no_match_with_plus_sign_from_name(self):
         msg = BecauseNodeIsBusy % 'centos6__192.168.1.12'
         assert util.from_label(msg) is None
+
+    def test_label_is_busy_unicode(self):
+        msg = BecauseLabelIsBusy % 'huge&&amd64'
+        assert util.from_label(msg) == 'wheezy'
 
 
 class TestOfflineLabel(object):


### PR DESCRIPTION
Otherwise it fails to parse properly when Jenkins returns them as seen on issue #129 :+1: 

```

[2019-08-13 19:46:04,394: INFO/ForkPoolWorker-3] found stuck task with name: ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=bionic,DIST=bionic,MACHINE_SIZE=huge [2019-08-13 19:46:04,394: INFO/ForkPoolWorker-3] reason was: Waiting for next available executor on ‘huge&&x86_64&&bionic’ [2019-08-13 19:46:04,395: WARNING/ForkPoolWorker-3] invalid syntax (<unknown>, line 1) [2019-08-13 19:46:04,395: WARNING/ForkPoolWorker-3] unable to match: ‘huge&&x86_64&&bionic’
--


```

In this case, the single quotes are actually utf-8 chars 2018 and 2019 respectively. By removing them like we do in other places, we ensure that these will go through cleanly.

The unit test added verified the problem. After making the changes in the helper function, the test passed.