### PR TITLE
prod_nodes: Create node template for pure Bionic slaves

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -90,6 +90,18 @@ nodes = {
         'labels': ['amd64', 'x86_64', 'trusty', 'huge', 'rebootable', 'xenial', 'bionic'],
         'provider': 'openstack'
     },
+    'bionic_huge': {
+        'script': dedent("""#!/bin/bash
+        apt-get update
+        apt-get install -y python-simplejson
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+huge+bionic+x86_64+rebootable&nodename=bionic_huge__%s" | bash
+        """),
+        'keyname': keyname,
+        'image_name': 'Ubuntu 18.04',
+        'size': 'hg-30-ssd',
+        'labels': ['amd64', 'x86_64', 'bionic', 'huge', 'rebootable'],
+        'provider': 'openstack'
+    },
     'centos6_small': {
         'script': dedent("""#!/bin/bash
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos6+x86_64+small+rebootable&nodename=centos6_small__%s" | bash"""),


### PR DESCRIPTION
For now, we want make check to only run on Bionic because:

1) We expect it to have python2 and python3 installed
2) All branches should build and test on bionic (but not any other distro)

Signed-off-by: David Galloway <dgallowa@redhat.com>