### PR TITLE
prod_nodes: Add template for CentOS8 cloud image

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -147,6 +147,18 @@ nodes = {
         'labels': ['amd64', 'x86_64', 'centos7', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
+    'centos8_huge': {
+        'script': dedent("""#!/bin/bash
+        yum install -y python2
+        ln -s /usr/bin/python2 /usr/bin/python
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos8+huge+x86_64+rebootable&ansible_python_interpreter=/usr/bin/python3&nodename=centos8_huge__%s" | bash
+        rm -f /usr/bin/python"""),
+        'keyname': keyname,
+        'image_name': 'centos8-cloud',
+        'size': 'hg-30-ssd',
+        'labels': ['amd64', 'x86_64', 'centos8', 'huge', 'rebootable'],
+        'provider': 'openstack'
+    },
     'ceph_build_xenial': {
         'script': dedent("""#!/bin/bash
         apt-get update


### PR DESCRIPTION
Installing python2 is needed for the jenkins_node library to run.  The symlink is needed because of `/usr/bin/env python` at the top of the library file.  Note the symlink is removed after the ansible playbook runs.

The `centos8-cloud` image is a qcow2 I built using `virt-builder` then uploaded to Openstack.

`virt-builder -v centos-8.0 --install cloud-init,curl,tar,cloud-utils-growpart,yum,python3,python2,python3-libselinux,libselinux-devel,python2-libs,selinux-policy-devel,createrepo,epel-release,java-1.8.0-openjdk,git,python3-virtualenv,libtool,autoconf,redhat-lsb-core,automake,cmake,binutils,bison,flex,gcc,gcc-c++,gettext,libtool,make,patch,pkgconfig,redhat-rpm-config,rpm-build,rpmdevtools,openssl-devel,libffi-devel --format qcow2 --selinux-relabel`

Signed-off-by: David Galloway <dgallowa@redhat.com>