### PR TITLE
Use new OVH instance flavors

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -12,7 +12,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 16.04',
-        'size': 'vps-ssd-1',
+        'size': 'c2-15',
         'labels': ['ceph_ansible_pr_trusty'],
         'provider': 'openstack',
         'storage': 10
@@ -26,7 +26,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 16.04',
-        'size': 'hg-30-flex',
+        'size': 'c2-30-flex',
         'labels': ['ceph_ansible_pr_xenial'],
         'provider': 'openstack'
     },
@@ -38,7 +38,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 17.04',
-        'size': 'hg-30-flex',
+        'size': 'c2-30-flex',
         'labels': ['ceph_ansible_pr_zesty', 'libvirt', 'vagrant', 'python3'],
         'provider': 'openstack'
     },
@@ -51,7 +51,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 16.04',
-        'size': 'vps-ssd-1',
+        'size': 'c2-15',
         'labels': ['amd64', 'x86_64', 'trusty', 'small', 'rebootable'],
         'provider': 'openstack'
     },
@@ -64,7 +64,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 16.04',
-        'size': 'hg-30-ssd',
+        'size': 'c2-30',
         'labels': ['trusty-pbuilder', 'amd64', 'x86_64', 'jessie', 'stretch', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -77,7 +77,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 16.04',
-        'size': 'hg-30-ssd',
+        'size': 'c2-30',
         'labels': ['trusty-pbuilder', 'trusty', 'amd64', 'x86_64', 'xenial', 'bionic', 'jessie', 'stretch', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -90,7 +90,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 16.04',
-        'size': 'hg-30-ssd',
+        'size': 'c2-30',
         'labels': ['amd64', 'x86_64', 'trusty', 'huge', 'rebootable', 'xenial', 'bionic'],
         'provider': 'openstack'
     },
@@ -102,7 +102,7 @@ nodes = {
         """),
         'keyname': keyname,
         'image_name': 'Ubuntu 18.04',
-        'size': 'hg-30-ssd',
+        'size': 'c2-30',
         'labels': ['amd64', 'x86_64', 'bionic', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -111,7 +111,7 @@ nodes = {
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos6+x86_64+small+rebootable&nodename=centos6_small__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'Centos 6',
-        'size': 'vps-ssd-1',
+        'size': 'c2-15',
         'labels': ['amd64', 'x86_64', 'centos6', 'small', 'rebootable'],
         'provider': 'openstack'
     },
@@ -120,7 +120,7 @@ nodes = {
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos6+x86_64+huge+rebootable&nodename=centos6_huge__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'Centos 6',
-        'size': 'hg-30-ssd',
+        'size': 'c2-30',
         'labels': ['amd64', 'x86_64', 'centos6', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -130,7 +130,7 @@ nodes = {
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave_libvirt/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=centos7+vagrant+libvirt&nodename=ceph_ansible_docker_centos7__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'Centos 7.4',
-        'size': 'hg-30-flex',
+        'size': 'c2-30-flex',
         'labels': ['vagrant', 'libvirt', 'centos7'],
         'provider': 'openstack'
     },
@@ -140,7 +140,7 @@ nodes = {
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos7+small+x86_64+rebootable&nodename=centos7_small__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'Centos 7.4',
-        'size': 'vps-ssd-1',
+        'size': 'c2-15',
         'labels': ['amd64', 'x86_64', 'centos7', 'small', 'rebootable'],
         'provider': 'openstack'
     },
@@ -150,7 +150,7 @@ nodes = {
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos7+huge+x86_64+rebootable&nodename=centos7_huge__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'Centos 7.4',
-        'size': 'hg-30-ssd',
+        'size': 'c2-30',
         'labels': ['amd64', 'x86_64', 'centos7', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -162,7 +162,7 @@ nodes = {
         rm -f /usr/bin/python"""),
         'keyname': keyname,
         'image_name': 'centos8-cloud',
-        'size': 'hg-30-ssd',
+        'size': 'c2-30',
         'labels': ['amd64', 'x86_64', 'centos8', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
@@ -174,7 +174,7 @@ nodes = {
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=python3+amd64+huge+xfs+ceph_build_xenial+x86_64+rebootable&nodename=ceph_build_xenial__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'Ubuntu 16.04',
-        'size': 'hg-30-ssd',
+        'size': 'c2-30',
         'labels': ['ceph_build_xenial', 'amd64', 'x86_64', 'xfs', 'huge', 'rebootable', 'python3'],
         'provider': 'openstack'
     },
@@ -185,7 +185,7 @@ nodes = {
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&osc_user={{ osc_user }}&osc_pass={{ osc_pass }}&labels=x86_64+amd64+huge+leap15&nodename=leap15_huge__%s" | bash"""),
         'keyname': keyname,
         'image_name': 'opensuse-15.1',
-        'size': 'hg-30-ssd',
+        'size': 'c2-30',
         'labels': ['leap15', 'huge', 'amd64', 'x86_64'],
         'provider': 'openstack'
     },


### PR DESCRIPTION
They reached out to me asking me to stop using the hg-* flavors due to lack of systems that could support them.

We tried to switch to these along with a different region a year or two ago but they didn't have capacity.  I've been assured they have capacity now.

Signed-off-by: David Galloway <dgallowa@redhat.com>