### PR TITLE
Use official CentOS 8.1 cloud image

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -156,12 +156,13 @@ nodes = {
     },
     'centos8_huge': {
         'script': dedent("""#!/bin/bash
-        yum install -y python2 ansible
+        yum install -y python2 python3 ansible
+        rm -f /usr/bin/python
         ln -s /usr/bin/python2 /usr/bin/python
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos8+huge+x86_64+rebootable&ansible_python_interpreter=/usr/bin/python3&nodename=centos8_huge__%s" | bash
         rm -f /usr/bin/python"""),
         'keyname': keyname,
-        'image_name': 'centos8-cloud',
+        'image_name': 'Centos 8.1',
         'size': 'c2-30',
         'labels': ['amd64', 'x86_64', 'centos8', 'huge', 'rebootable'],
         'provider': 'openstack'


### PR DESCRIPTION
This is actually a pre-baked cloud image I ran `slave.yml` against except for the `jenkins_node` task.

For whatever reason, dnf transactions were taking FOREVER during cloud-init and the setup would timeout.  I confirmed this cloud image along with mita changes is working now though.

Signed-off-by: David Galloway <dgallowa@redhat.com>