### PR TITLE
prod_nodes: Install epel on centos&&small before ansible

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -136,6 +136,7 @@ nodes = {
     },
     'centos7_small': {
         'script': dedent("""#!/bin/bash
+        yum install -y epel-release
         yum install -y ansible
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos7+small+x86_64+rebootable&nodename=centos7_small__%s" | bash"""),
         'keyname': keyname,


### PR DESCRIPTION
Ansible is in epel so they need epel first.  This must have been broken since https://github.com/ceph/mita/commit/09171338ad09f49333edd21caf8a4f300f9c550f

Signed-off-by: David Galloway <dgallowa@redhat.com>