### PR TITLE
prod_nodes: Create centos7_gigantic node

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -170,6 +170,17 @@ nodes = {
         'labels': ['amd64', 'x86_64', 'centos8', 'huge', 'rebootable'],
         'provider': 'openstack'
     },
+    'centos7_gigantic': {
+        'script': dedent("""#!/bin/bash
+        yum install -y epel-release
+        yum install -y ansible
+        curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos7+gigantic+x86_64+rebootable&nodename=centos7_gigantic__%s" | bash"""),
+        'keyname': keyname,
+        'image_name': 'Centos 7.4',
+        'size': 'c2-120',
+        'labels': ['amd64', 'x86_64', 'centos7', 'huge', 'rebootable', 'gigantic'],
+        'provider': 'openstack'
+    },
     'ceph_build_xenial': {
         'script': dedent("""#!/bin/bash
         add-apt-repository -y ppa:ansible/ansible


### PR DESCRIPTION
I ran some stats gathering on shaman and discovered the CentOS7 braggi builders were extremely underused.  So I reimaged 3 of them to CentOS8.  Then, yesterday, Yuri had a bunch of PR testing to do for the next Nautilus release which involved a lot of CentOS7 builds needing to be created.  I know we are trying to lessen our OVH usage but I think CentOS7 is the best distro for us to dynamically spin up nodes for since it will be the least used of them (Ubuntu/CentOS8) all.

Signed-off-by: David Galloway <dgallowa@redhat.com>