### PR TITLE
deploy: Unpin centos7 nodes. Use latest OVH-provided Centos 7.

### DIFF
--- a/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
+++ b/deploy/playbooks/roles/common/templates/prod_nodes.py.j2
@@ -130,7 +130,7 @@ nodes = {
         yum install -y ansible
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=centos7+vagrant+libvirt&libvirt=true&nodename=ceph_ansible_docker_centos7__%s" | bash"""),
         'keyname': keyname,
-        'image_name': 'Centos 7.4',
+        'image_name': 'Centos 7',
         'size': 'c2-30',
         'labels': ['vagrant', 'libvirt', 'centos7'],
         'provider': 'openstack'
@@ -141,7 +141,7 @@ nodes = {
         yum install -y ansible
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos7+small+x86_64+rebootable&nodename=centos7_small__%s" | bash"""),
         'keyname': keyname,
-        'image_name': 'Centos 7.4',
+        'image_name': 'Centos 7',
         'size': 'c2-15',
         'labels': ['amd64', 'x86_64', 'centos7', 'small', 'rebootable'],
         'provider': 'openstack'
@@ -152,7 +152,7 @@ nodes = {
         yum install -y ansible
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos7+huge+x86_64+rebootable&nodename=centos7_huge__%s" | bash"""),
         'keyname': keyname,
-        'image_name': 'Centos 7.4',
+        'image_name': 'Centos 7',
         'size': 'c2-30',
         'labels': ['amd64', 'x86_64', 'centos7', 'huge', 'rebootable'],
         'provider': 'openstack'
@@ -176,7 +176,7 @@ nodes = {
         yum install -y ansible
         curl -u {{ prado_user | default('admin') }}:{{ prado_token }} -L "{{ prado_url }}/setup/slave/?token={{ jenkins_prado_token }}&api_uri={{ jenkins_url }}&jenkins_credentials_uuid={{ jenkins_credentials_uuid }}&executors=1&labels=amd64+centos7+gigantic+x86_64+rebootable&nodename=centos7_gigantic__%s" | bash"""),
         'keyname': keyname,
-        'image_name': 'Centos 7.4',
+        'image_name': 'Centos 7',
         'size': 'c2-120',
         'labels': ['amd64', 'x86_64', 'centos7', 'huge', 'rebootable', 'gigantic'],
         'provider': 'openstack'


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>